### PR TITLE
Fix syntax error in the README (else ... else)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ tickets.each_error do |error|
   else
     puts error.message
     # => "This indicates the entire request had an error"
-  else
+  end
 end
 
 # Later, after the Expo push notification service has delivered the


### PR DESCRIPTION
When running the example code in the README, an error is encountered because the `else` block is closed with `else` rather than the expected `end`.