### PR TITLE
Remove puts _params in Push Notification

### DIFF
--- a/lib/push/notification.rb
+++ b/lib/push/notification.rb
@@ -330,8 +330,6 @@ module Expo
       end
 
       def as_json
-        puts _params
-
         { to: recipients }.merge(_params.compact)
       end
 


### PR DESCRIPTION
Removes output when calling `as_json` method.

Why? Output gets printed in test suite:
```bash
> rspec spec/models/push_notification_spec.rb

Randomized with seed 26855

PushNotification
  #send_notification
    calls SendPushNotifications
  #to_expo
{:title=>"Title", :body=>"Message", :sound=>"bam"}
    gets converted to Expo push notification
```