### PR TITLE
Expose related token for created Ticket

### DIFF
--- a/lib/push/chunk.rb
+++ b/lib/push/chunk.rb
@@ -49,6 +49,10 @@ module Expo
         notifications.map(&:as_json)
       end
 
+      def all_recipients
+        notifications.flat_map(&:recipients)
+      end
+
       private
 
       attr_accessor :notifications

--- a/lib/push/client.rb
+++ b/lib/push/client.rb
@@ -183,6 +183,7 @@ module Expo
 
         threads = Chunk.for(notifications).map do |chunk|
           expected_count = chunk.count
+          tokens = chunk.all_recipients
 
           Thread.new do
             pool.with do |http|
@@ -197,7 +198,10 @@ module Expo
               elsif !data.is_a?(Array) || data.length != expected_count
                 TicketsExpectationFailed.new(expected_count: expected_count, data: data)
               else
-                data.map { |ticket| Ticket.new(ticket) }
+                data.map do |ticket|
+                  currentTicketToken = tokens.shift(1)[0]
+                  Ticket.new(ticket, currentTicketToken)
+                end
               end
             end
           end

--- a/lib/push/client.rb
+++ b/lib/push/client.rb
@@ -184,7 +184,6 @@ module Expo
         threads = Chunk.for(notifications).map do |chunk|
           expected_count = chunk.count
           tokens = chunk.all_recipients
-
           Thread.new do
             pool.with do |http|
               response = http.post(PUSH_API_URL, json: chunk.as_json)
@@ -199,8 +198,8 @@ module Expo
                 TicketsExpectationFailed.new(expected_count: expected_count, data: data)
               else
                 data.map do |ticket|
-                  currentTicketToken = tokens.shift(1)[0]
-                  Ticket.new(ticket, currentTicketToken)
+                  current_ticket_token = tokens.shift(1)[0]
+                  Ticket.new(ticket, current_ticket_token)
                 end
               end
             end

--- a/lib/push/receipts.rb
+++ b/lib/push/receipts.rb
@@ -33,6 +33,10 @@ module Expo
         data.fetch('message')
       end
 
+      def error_message
+        data.fetch('details').fetch('error')
+      end
+
       def explain
         Expo::Push::Error.explain((data['details'] || {})['error'])
       end

--- a/lib/push/tickets.rb
+++ b/lib/push/tickets.rb
@@ -12,10 +12,11 @@ module Expo
     # valid. This is exposed via #original_push_token.
     #
     class Ticket
-      attr_reader :data
+      attr_reader :data, :token
 
-      def initialize(data)
+      def initialize(data, token)
         self.data = data
+        self.token = token
       end
 
       def id
@@ -23,13 +24,7 @@ module Expo
       end
 
       def original_push_token
-        return nil if ok?
-
-        if message.include?('PushToken[')
-          return /Expo(?:nent)?PushToken\[(?:[^\]]+?)\]/.match(message) { |match| match[0] }
-        end
-
-        /\A[a-z\d]{8}-[a-z\d]{4}-[a-z\d]{4}-[a-z\d]{4}-[a-z\d]{12}\z/i.match(message) { |match| match[0] }
+        token
       end
 
       def message
@@ -50,7 +45,7 @@ module Expo
 
       private
 
-      attr_writer :data
+      attr_writer :data, :token
     end
 
     ##
@@ -77,6 +72,13 @@ module Expo
       def ids
         [].tap do |ids|
           each { |ticket| ids << ticket.id }
+        end
+      end
+
+      def tokens_by_receipt_id_hash
+        tokens_by_receipt_id = Hash.new { |hash, key| hash[key] = [] }
+        tokens_by_receipt_id.tap do |hash|
+          each { |ticket| hash[ticket.id] = ticket.original_push_token }
         end
       end
 

--- a/lib/push/tickets.rb
+++ b/lib/push/tickets.rb
@@ -75,8 +75,8 @@ module Expo
         end
       end
 
-      def tokens_by_receipt_id_hash
-        tokens_by_receipt_id = Hash.new { |hash, key| hash[key] = [] }
+      def token_by_receipt_id
+        tokens_by_receipt_id = {}
         tokens_by_receipt_id.tap do |hash|
           each { |ticket| hash[ticket.id] = ticket.original_push_token }
         end


### PR DESCRIPTION

# Background
This pull request aims to address the issue of handling receipts with error status. Currently, the expo-server-sdk-ruby implementation on the `original_push_token` relies on field message exposed by the Expo API response to access the push token associated with a receipt.

# Problem
An issue has been identified (see [GitHub issue #7795](https://github.com/expo/expo/issues/7795)) where the Expo API response no longer includes the push token for the respective receipt. Consequently, there is currently no way to retrieve the push token from a receipt.

# Proposed Solution
To overcome this problem, we propose the following solution: since the Expo API returns the receipt results in the same order as the push notifications are sent, we can determine the token associated with each receipt ID.

## Changes
1. Added the `all_recipients` method to the `Chunk` class, which retrieves all the tokens to which push notifications are being sent.
2. Added the `token` parameter to the constructor of the `Ticket` class.
3. Replaced the `original_push_token` method with the new token supplied in the constructor.
4. Added the `token_by_receipt_id` method, which returns a hash mapping tokens to their respective receipt IDs.

## Example Usage
Here is a small code snippet demonstrating the usage of the newly added functions:

```ruby
token_by_receipt_id = tickets.token_by_receipt_id
batches = tickets.batch_ids
batches.each do |current_batch_receipt_ids|
  push_notification_receipt_ids = []
  current_batch_receipt_ids.each do |receipt_id|
    expo_pn_token = token_by_receipt_id[receipt_id]
    # Rest of the code...
  end
end
```

These changes will enable the retrieval of push tokens associated with receipts, allowing for proper handling of receipts with error status.