### PR TITLE
fix: set authorization to http headers

### DIFF
--- a/lib/push/client.rb
+++ b/lib/push/client.rb
@@ -256,7 +256,7 @@ module Expo
             'User-Agent': format('expo-server-sdk-ruby/%<version>s', version: VERSION)
           )
 
-          http = http.headers('Authorization', "Bearer #{access_token}") if access_token
+          http = http.auth("Bearer #{access_token}") if access_token
 
           # All requests are allowed to automatically gzip
           http = http.use(:auto_inflate)


### PR DESCRIPTION
### Context:
An error is thrown when `Expo::Push::Client` is instantiated with an access token (see https://github.com/SleeplessByte/expo-server-sdk-ruby/issues/3)

### Problem:
`http.headers` should be called with an Hash while 2 arguments were passed here.

### Solution:
According to http [wiki](https://github.com/httprb/http/wiki/Authorization-Header), a more straightforward solution is to directly use `http.auth`
