### PR TITLE
Add support for iOS background notifications

### DIFF
--- a/lib/push/notification.rb
+++ b/lib/push/notification.rb
@@ -280,6 +280,23 @@ module Expo
       end
 
       ##
+      # Set or overwrite content available.
+      #
+      # Must be a boolean or nil, or an ArgumentError is raised.
+      #
+      # On iOS, use this to trigger a background fetch action.
+      # Under normal circumstances, the "content-available" flag should launch
+      # your app if it isn't running and wasn't killed by the user. However,
+      # this is ultimately decided by the OS, so it might not always happen.
+      #
+      def content_available(value)
+        raise ArgumentError, 'content_available must be boolean or nil' unless [true, false, nil].include?(value)
+
+        _params[:contentAvailable] = value
+        self
+      end
+
+      ##
       # Set or overwrite the mutability flag.
       #
       # Use nil to use the defaults.


### PR DESCRIPTION
This PR implements background notifications: https://docs.expo.dev/versions/latest/sdk/notifications/#background-notifications


According to https://github.com/expo/expo/issues/13767#issuecomment-1659559611, the solution is to add `_contentAvailable: true` to the payload.