### PR TITLE
Update PUSH_API_URL to use FCM HTTP v1 API

### DIFF
--- a/lib/push/client.rb
+++ b/lib/push/client.rb
@@ -140,7 +140,7 @@ module Expo
     BASE_URL = 'https://exp.host'
     BASE_API_URL = '/--/api/v2'
 
-    PUSH_API_URL = "#{BASE_API_URL}/push/send"
+    PUSH_API_URL = "#{BASE_API_URL}/push/send?useFcmV1=true"
     RECEIPTS_API_URL = "#{BASE_API_URL}/push/getReceipts"
 
     ##


### PR DESCRIPTION
On June 20th, Google will officially discontinue the FCM legacy API, necessitating a migration to the newer FCM HTTP v1 API. This change affects all developers using the legacy API, as the credential requirements differ between the two versions.

**Impact:**
Currently, the projects using Expo's server SDK for Ruby are configured to utilize the FCM legacy API. This existing configuration cannot be automatically updated to support the FCM HTTP v1 API due to different credential requirements.

**Required Changes:**

Update the Expo server SDK to explicitly support the FCM HTTP v1 API.

For more details on the migration process and what this means for your projects, please read the official Expo blog post: [Expo Push Notifications: Migrating to FCM v1](https://expo.dev/blog/expo-push-notifications-migrating-to-fcm-v1).